### PR TITLE
♻️ - Movido Validatable para o namespace PMQ.Notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+# Valida todo push e PR. O publish-nuget.yml só dispara em tag, então sem isto
+# uma regressão só apareceria na hora de publicar.
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  build:
+    name: Build e testes
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Run tests
+        run: dotnet test --configuration Release --no-build --verbosity normal

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -5,9 +5,15 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
-  publish:
-    name: Publish Package
+  test:
+    name: Run Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -17,7 +23,11 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          # O SDK 10 compila os dois targets; o runtime 8 é necessário para executar
+          # os testes compilados para net8.0.
+          dotnet-version: |
+            8.0.x
+            10.0.x
 
       - name: Restore dependencies
         run: dotnet restore
@@ -25,8 +35,50 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
 
+      - name: Run tests
+        run: dotnet test --configuration Release --no-build --verbosity normal
+
+  publish:
+    name: Publish Package
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      # A versão vem da tag em build e pack: assembly e pacote nunca divergem,
+      # e o <Version> do .csproj passa a ser apenas o padrão de desenvolvimento.
+      - name: Build
+        run: dotnet build --configuration Release --no-restore -p:Version=${{ steps.version.outputs.VERSION }}
+
       - name: Pack
-        run: dotnet pack --configuration Release --no-build --output ./nupkg
+        run: dotnet pack --configuration Release --no-build --output ./nupkg -p:Version=${{ steps.version.outputs.VERSION }}
+
+      - name: Verify NuGet API key
+        env:
+          NUGET_KEY: ${{ secrets.PMQ_NUGET_KEY }}
+        run: |
+          if [ -z "$NUGET_KEY" ]; then
+            echo "::error::PMQ_NUGET_KEY não está configurado (Settings > Secrets and variables > Actions)."
+            exit 1
+          fi
 
       - name: Publish to NuGet
-        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.PMQ_NUGET_KEY }} --source https://api.nuget.org/v3/index.json
+        env:
+          NUGET_KEY: ${{ secrets.PMQ_NUGET_KEY }}
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key "$NUGET_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,40 @@
+<Project>
+
+  <PropertyGroup Label="Framework">
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Qualidade">
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Build">
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Segurança">
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <NuGetAuditLevel>low</NuGetAuditLevel>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Empacotamento">
+    <Authors>Pablo Mickael Quevedo</Authors>
+    <Company>Pablo Mickael Quevedo</Company>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryType>git</RepositoryType>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,20 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="FluentValidation" Version="12.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Label="Testes">
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
+</Project>

--- a/PMQ.Notifications.sln
+++ b/PMQ.Notifications.sln
@@ -5,19 +5,52 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PMQ.Notifications", "src\PMQ.Notifications\PMQ.Notifications.csproj", "{4786307F-218B-442A-A14B-3083B092A6FB}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PMQ.Notifications.Tests", "tests\PMQ.Notifications.Tests\PMQ.Notifications.Tests.csproj", "{6F767FA0-1610-4BD0-84DC-EDA2499B1347}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{4786307F-218B-442A-A14B-3083B092A6FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4786307F-218B-442A-A14B-3083B092A6FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4786307F-218B-442A-A14B-3083B092A6FB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4786307F-218B-442A-A14B-3083B092A6FB}.Debug|x64.Build.0 = Debug|Any CPU
+		{4786307F-218B-442A-A14B-3083B092A6FB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4786307F-218B-442A-A14B-3083B092A6FB}.Debug|x86.Build.0 = Debug|Any CPU
 		{4786307F-218B-442A-A14B-3083B092A6FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4786307F-218B-442A-A14B-3083B092A6FB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4786307F-218B-442A-A14B-3083B092A6FB}.Release|x64.ActiveCfg = Release|Any CPU
+		{4786307F-218B-442A-A14B-3083B092A6FB}.Release|x64.Build.0 = Release|Any CPU
+		{4786307F-218B-442A-A14B-3083B092A6FB}.Release|x86.ActiveCfg = Release|Any CPU
+		{4786307F-218B-442A-A14B-3083B092A6FB}.Release|x86.Build.0 = Release|Any CPU
+		{6F767FA0-1610-4BD0-84DC-EDA2499B1347}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F767FA0-1610-4BD0-84DC-EDA2499B1347}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F767FA0-1610-4BD0-84DC-EDA2499B1347}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6F767FA0-1610-4BD0-84DC-EDA2499B1347}.Debug|x64.Build.0 = Debug|Any CPU
+		{6F767FA0-1610-4BD0-84DC-EDA2499B1347}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6F767FA0-1610-4BD0-84DC-EDA2499B1347}.Debug|x86.Build.0 = Debug|Any CPU
+		{6F767FA0-1610-4BD0-84DC-EDA2499B1347}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F767FA0-1610-4BD0-84DC-EDA2499B1347}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F767FA0-1610-4BD0-84DC-EDA2499B1347}.Release|x64.ActiveCfg = Release|Any CPU
+		{6F767FA0-1610-4BD0-84DC-EDA2499B1347}.Release|x64.Build.0 = Release|Any CPU
+		{6F767FA0-1610-4BD0-84DC-EDA2499B1347}.Release|x86.ActiveCfg = Release|Any CPU
+		{6F767FA0-1610-4BD0-84DC-EDA2499B1347}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{6F767FA0-1610-4BD0-84DC-EDA2499B1347} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {93B32D8D-DCF7-4E44-BB77-F493B3ADA239}

--- a/README.md
+++ b/README.md
@@ -30,29 +30,21 @@ The package provides a notification context (`INotificationContext`) to register
 - `NotificationContext`: Default implementation of `INotificationContext`.
 - `Notification`: Represents a single notification (key, message, type).
 - `NotificationType`: Enum-like value object for message categorization.
-- `Validatable`: Abstract base class that provides validation capabilities using FluentValidation.
+- `Validatable`: Abstract base class that lets an object accumulate its own rule violations.
+- `NotificationContextExtensions`: Bridges a `Validatable` into an `INotificationContext`.
 
 ---
 
-## Validatable Base Class
+## Validatable
 
-The `Validatable` abstract class provides a foundation for creating domain entities and value objects with built-in validation support. It manages validation errors using FluentValidation and offers methods to add, clear, and query validation failures.
-
-### Key features
-
-- **ValidationResult**: Stores all validation errors for the object.
-- **IsValid / IsInvalid**: Properties to quickly check the validation state.
-- **ClearValidation()**: Clears all accumulated validation errors.
-- **AddNotification()**: Protected methods to add validation failures by property and message.
-- **AddNotifications()**: Adds multiple validation failures at once.
-- **[JsonIgnore]**: Validation properties are automatically excluded from JSON serialization.
-
-### Example usage
+`Validatable` gives domain objects a place to record why they are invalid, **without throwing**.
+A broken business rule is an expected outcome, not exceptional control flow — and unlike an
+exception, which stops at the first problem, a `Validatable` reports every failure at once.
 
 ```csharp
-using PMQ.Notifications.Base;
+using PMQ.Notifications;
 
-public class Product : Validatable
+public sealed class Product : Validatable
 {
     public string Name { get; private set; }
     public decimal Price { get; private set; }
@@ -69,16 +61,39 @@ public class Product : Validatable
         Price = price;
     }
 }
-
-// Usage
-var product = new Product("", -10);
-
-if (product.IsInvalid)
-{
-    var errors = product.ValidationResult.Errors;
-    // Handle validation errors
-}
 ```
+
+| Member | Purpose |
+|---|---|
+| `ValidationResult` | All accumulated failures (FluentValidation type). |
+| `IsValid` / `IsInvalid` | Quick state check. |
+| `ClearValidation()` | Drops the accumulated failures. |
+| `AddNotification(property, message)` | Records one failure. Protected — only the object itself decides it is invalid. |
+| `AddNotifications(failures)` | Records several at once. |
+
+Validation members are marked `[JsonIgnore]`, so they never leak into serialized payloads.
+
+### Promoting failures to the request
+
+`AddFrom` copies a `Validatable`'s failures into the request's notification context, so the
+domain object never has to know about the request it happens to be serving:
+
+```csharp
+var product = new Product(request.Name, request.Price);
+
+// NotificationType.BusinessRule → HTTP 422 with PMQ.ErrorHandling.
+if (notificationContext.AddFrom(product, NotificationType.BusinessRule))
+    return default;
+
+await repository.AddAsync(product, cancellationToken);
+```
+
+It returns `true` when there were failures, and also accepts a collection when several objects
+must be validated together.
+
+> **Namespace note:** until 1.0.7 this type shipped under `PMQ.Notification` (singular) by
+> mistake. It now lives in `PMQ.Notifications` alongside everything else; the old name still
+> works but is marked `[Obsolete]` and will be removed in 2.0.
 
 ---
 

--- a/src/PMQ.Notifications/Base/ObsoleteValidatable.cs
+++ b/src/PMQ.Notifications/Base/ObsoleteValidatable.cs
@@ -1,0 +1,21 @@
+namespace PMQ.Notification;
+
+/// <summary>
+/// Compatibility shim for the misspelled <c>PMQ.Notification</c> namespace.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every other type in this package lives in <c>PMQ.Notifications</c> (plural); this single
+/// type shipped under the singular form by mistake. The type moved to
+/// <see cref="Notifications.Validatable"/> and this subclass keeps existing code compiling.
+/// </para>
+/// <para>
+/// Because it derives from the real type, an entity declared as
+/// <c>class Order : PMQ.Notification.Validatable</c> is still a
+/// <c>PMQ.Notifications.Validatable</c> and works with everything that expects it.
+/// Change the <c>using</c> to <c>PMQ.Notifications</c> to clear the warning.
+/// </para>
+/// <para>Scheduled for removal in 2.0.</para>
+/// </remarks>
+[Obsolete("Use PMQ.Notifications.Validatable. The PMQ.Notification (singular) namespace was a typo and will be removed in 2.0.")]
+public abstract class Validatable : Notifications.Validatable;

--- a/src/PMQ.Notifications/Base/Validatable.cs
+++ b/src/PMQ.Notifications/Base/Validatable.cs
@@ -1,11 +1,16 @@
-namespace PMQ.Notification;
-
-using FluentValidation.Results;
 using System.Text.Json.Serialization;
+using FluentValidation.Results;
+
+namespace PMQ.Notifications;
 
 /// <summary>
 /// Base abstract class that provides validation capabilities to derived classes.
 /// </summary>
+/// <remarks>
+/// Accumulates rule violations instead of throwing, so that a broken business rule stays an
+/// expected outcome rather than exceptional control flow. Callers check <see cref="IsValid"/>
+/// and decide what to do with <see cref="ValidationResult"/>.
+/// </remarks>
 public abstract class Validatable
 {
     /// <summary>

--- a/src/PMQ.Notifications/Extensions/NotificationContextExtensions.cs
+++ b/src/PMQ.Notifications/Extensions/NotificationContextExtensions.cs
@@ -1,0 +1,76 @@
+namespace PMQ.Notifications;
+
+/// <summary>
+/// Bridges the validation state accumulated by a <see cref="Validatable"/> into an
+/// <see cref="INotificationContext"/>.
+/// </summary>
+/// <remarks>
+/// Lets a domain object stay unaware of the request it happens to be serving: it accumulates
+/// its own rule violations, and the caller decides whether and how to promote them.
+/// </remarks>
+public static class NotificationContextExtensions
+{
+    /// <summary>
+    /// Copies the validation failures of <paramref name="validatable"/> into the context.
+    /// </summary>
+    /// <param name="notificationContext">The notification context to add to.</param>
+    /// <param name="validatable">The validated object.</param>
+    /// <param name="type">
+    /// Category applied to the generated notifications. Defaults to
+    /// <see cref="NotificationType.Validation"/>. Pass <see cref="NotificationType.BusinessRule"/>
+    /// when the failures come from a domain invariant rather than from malformed input.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when there were failures — and therefore the operation should stop.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="notificationContext"/> or <paramref name="validatable"/> is null.
+    /// </exception>
+    public static bool AddFrom(
+        this INotificationContext notificationContext,
+        Validatable validatable,
+        NotificationType? type = null)
+    {
+        ArgumentNullException.ThrowIfNull(notificationContext);
+        ArgumentNullException.ThrowIfNull(validatable);
+
+        if (validatable.IsValid)
+            return false;
+
+        foreach (var failure in validatable.ValidationResult.Errors)
+        {
+            notificationContext.Add(
+                failure.PropertyName ?? string.Empty,
+                failure.ErrorMessage,
+                type ?? NotificationType.Validation);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Copies the validation failures of every object in <paramref name="validatables"/> into the context.
+    /// </summary>
+    /// <param name="notificationContext">The notification context to add to.</param>
+    /// <param name="validatables">The validated objects.</param>
+    /// <param name="type">Category applied to the generated notifications.</param>
+    /// <returns><see langword="true"/> when at least one object had failures.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="notificationContext"/> or <paramref name="validatables"/> is null.
+    /// </exception>
+    public static bool AddFrom(
+        this INotificationContext notificationContext,
+        IEnumerable<Validatable> validatables,
+        NotificationType? type = null)
+    {
+        ArgumentNullException.ThrowIfNull(notificationContext);
+        ArgumentNullException.ThrowIfNull(validatables);
+
+        var hasFailures = false;
+
+        foreach (var validatable in validatables)
+            hasFailures |= notificationContext.AddFrom(validatable, type);
+
+        return hasFailures;
+    }
+}

--- a/src/PMQ.Notifications/PMQ.Notifications.csproj
+++ b/src/PMQ.Notifications/PMQ.Notifications.csproj
@@ -1,31 +1,20 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <PackageId>PMQ.Notifications</PackageId>
-    <Version>1.0.7</Version>
-    <Authors>Pablo Mickael Quevedo</Authors>
-    <Company>Pablo Mickael Quevedo</Company>
+    <Version>1.1.0</Version>
     <Product>PMQ.Notifications</Product>
     <Description>
       A package for managing notifications and validations in .NET applications, making it easy to control messages, errors, and business rules in a centralized and strongly-typed way.
     </Description>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/PabloMickaelQuevedo/PMQ.Notifications</PackageProjectUrl>
     <RepositoryUrl>https://github.com/PabloMickaelQuevedo/PMQ.Notifications.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
     <PackageTags>notifications;validation;business-rules;dotnet;domain;ddd</PackageTags>
     <IncludeLicenseFile>true</IncludeLicenseFile>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Optimize>true</Optimize>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="12.1.1" />
+    <PackageReference Include="FluentValidation" />
   </ItemGroup>
 
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <!--
+      Código de teste não é distribuído: as regras de design de API pública só geram ruído em fixtures.
+    -->
+    <AnalysisLevel>latest-minimum</AnalysisLevel>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Shouldly" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Shouldly" />
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/PMQ.Notifications.Tests/NotificationContextExtensionsTests.cs
+++ b/tests/PMQ.Notifications.Tests/NotificationContextExtensionsTests.cs
@@ -1,0 +1,97 @@
+using PMQ.Notifications;
+
+namespace PMQ.Notifications.Tests;
+
+public class NotificationContextExtensionsTests
+{
+    private sealed class Order : Validatable
+    {
+        public void Reject(string property, string message) => AddNotification(property, message);
+    }
+
+    private readonly NotificationContext _context = new();
+
+    [Fact]
+    public void AddFrom_WithValidObject_ShouldAddNothingAndReturnFalse()
+    {
+        var added = _context.AddFrom(new Order());
+
+        added.ShouldBeFalse();
+        _context.HasNotifications.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AddFrom_WithInvalidObject_ShouldCopyPropertyAsKeyAndMessage()
+    {
+        var order = new Order();
+        order.Reject("Total", "Total must be positive.");
+
+        var added = _context.AddFrom(order);
+
+        added.ShouldBeTrue();
+
+        var notification = _context.Notifications.ShouldHaveSingleItem();
+        notification.Key.ShouldBe("Total");
+        notification.Message.ShouldBe("Total must be positive.");
+    }
+
+    [Fact]
+    public void AddFrom_ByDefault_ShouldUseValidationType()
+    {
+        var order = new Order();
+        order.Reject("Total", "Total must be positive.");
+
+        _context.AddFrom(order);
+
+        _context.HasType(NotificationType.Validation).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AddFrom_WithExplicitType_ShouldUseIt()
+    {
+        var order = new Order();
+        order.Reject("Total", "Total must be positive.");
+
+        _context.AddFrom(order, NotificationType.BusinessRule);
+
+        _context.HasType(NotificationType.BusinessRule).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AddFrom_WithCollection_ShouldAggregateEveryFailure()
+    {
+        var first = new Order();
+        first.Reject("Total", "Total must be positive.");
+
+        var second = new Order();
+        second.Reject("Customer", "Customer is required.");
+
+        var added = _context.AddFrom([first, second, new Order()]);
+
+        added.ShouldBeTrue();
+        _context.Notifications.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void AddFrom_WithCollectionOfValidObjects_ShouldReturnFalse()
+    {
+        var added = _context.AddFrom([new Order(), new Order()]);
+
+        added.ShouldBeFalse();
+        _context.HasNotifications.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AddFrom_WithNullContext_ShouldThrow()
+    {
+        INotificationContext context = null!;
+
+        Should.Throw<ArgumentNullException>(() => context.AddFrom(new Order()));
+    }
+
+    [Fact]
+    public void AddFrom_WithNullValidatable_ShouldThrow()
+    {
+        Should.Throw<ArgumentNullException>(() => _context.AddFrom((Validatable)null!));
+    }
+}

--- a/tests/PMQ.Notifications.Tests/PMQ.Notifications.Tests.csproj
+++ b/tests/PMQ.Notifications.Tests/PMQ.Notifications.Tests.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\PMQ.Notifications\PMQ.Notifications.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/PMQ.Notifications.Tests/ValidatableTests.cs
+++ b/tests/PMQ.Notifications.Tests/ValidatableTests.cs
@@ -1,0 +1,115 @@
+using FluentValidation.Results;
+using PMQ.Notifications;
+
+namespace PMQ.Notifications.Tests;
+
+public class ValidatableTests
+{
+    private sealed class Order : Validatable
+    {
+        public void Reject(string property, string message) => AddNotification(property, message);
+
+        public void Reject(string message) => AddNotification(message);
+
+        public void RejectMany(IEnumerable<ValidationFailure> failures) => AddNotifications(failures);
+    }
+
+    [Fact]
+    public void NewInstance_ShouldBeValid()
+    {
+        var order = new Order();
+
+        order.IsValid.ShouldBeTrue();
+        order.IsInvalid.ShouldBeFalse();
+        order.ValidationResult.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void AddNotification_WithProperty_ShouldRecordPropertyAndMessage()
+    {
+        var order = new Order();
+
+        order.Reject("Total", "Total must be positive.");
+
+        order.IsInvalid.ShouldBeTrue();
+
+        var failure = order.ValidationResult.Errors.ShouldHaveSingleItem();
+        failure.PropertyName.ShouldBe("Total");
+        failure.ErrorMessage.ShouldBe("Total must be positive.");
+    }
+
+    [Fact]
+    public void AddNotification_WithoutProperty_ShouldLeavePropertyEmpty()
+    {
+        var order = new Order();
+
+        order.Reject("Something went wrong.");
+
+        order.ValidationResult.Errors.ShouldHaveSingleItem().PropertyName.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void AddNotification_WithBlankMessage_ShouldBeIgnored()
+    {
+        var order = new Order();
+
+        order.Reject("Total", "   ");
+
+        order.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AddNotification_WithDuplicate_ShouldRecordOnlyOnce()
+    {
+        var order = new Order();
+
+        order.Reject("Total", "Total must be positive.");
+        order.Reject("Total", "Total must be positive.");
+
+        order.ValidationResult.Errors.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void AddNotification_WithSameMessageOnAnotherProperty_ShouldRecordBoth()
+    {
+        var order = new Order();
+
+        order.Reject("Total", "Required.");
+        order.Reject("Customer", "Required.");
+
+        order.ValidationResult.Errors.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void AddNotifications_ShouldRecordEveryFailure()
+    {
+        var order = new Order();
+
+        order.RejectMany([new ValidationFailure("A", "first"), new ValidationFailure("B", "second")]);
+
+        order.ValidationResult.Errors.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ClearValidation_ShouldMakeTheObjectValidAgain()
+    {
+        var order = new Order();
+        order.Reject("Total", "Total must be positive.");
+
+        order.ClearValidation();
+
+        order.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ObsoleteNamespaceShim_ShouldStillBeAValidatable()
+    {
+        // Garante que o alias depreciado continua intercambiável com o tipo real,
+        // para que consumidores anteriores à correção do namespace sigam compilando.
+        // O global:: é necessário porque, dentro deste namespace, `Notification` sozinho
+        // resolve para o tipo PMQ.Notifications.Notification e não para o namespace.
+#pragma warning disable CS0618 // Type or member is obsolete
+        typeof(global::PMQ.Notification.Validatable).IsAssignableTo(typeof(Validatable)).ShouldBeTrue();
+#pragma warning restore CS0618
+    }
+}


### PR DESCRIPTION
## O que muda

O `Validatable` era o único tipo do pacote no namespace `PMQ.Notification` (singular), por engano — todo o resto vive em `PMQ.Notifications`. O tipo foi movido para o namespace correto.

Para não quebrar quem já herda dele, o nome antigo virou uma subclasse marcada como `[Obsolete]`:

```csharp
[Obsolete("Use PMQ.Notifications.Validatable. ...")]
public abstract class Validatable : Notifications.Validatable;
```

Como ela **deriva** do tipo real, uma entidade declarada como `class Order : PMQ.Notification.Validatable` continua sendo um `PMQ.Notifications.Validatable` e funciona com tudo que espera esse tipo. Só emite aviso. Remoção prevista para a 2.0.

## Novidade: `AddFrom`

`NotificationContextExtensions.AddFrom` promove as falhas acumuladas em um `Validatable` para o `INotificationContext` da requisição. Os dois tipos vivem neste pacote, então é aqui que a ponte pertence.

```csharp
if (notificationContext.AddFrom(product, NotificationType.BusinessRule))
    return default;
```

Retorna `true` quando havia falhas, e tem sobrecarga para coleção.

## Infraestrutura

- Multi-target `net8.0;net10.0` — consumidores em .NET 10 param de carregar assemblies 8.x
- Central Package Management
- Analisadores em `latest-recommended`, `NuGetAudit` em `all`/`low`, warnings como erro no Release
- **Projeto de testes criado** — era o único repositório do ecossistema PMQ sem nenhum teste (17 testes, nos dois TFMs)
- CI em push/PR; antes os testes só rodavam ao criar tag
- `publish-nuget.yml` corrigido: fixava `dotnet-version: 8.0.x`, que não compilaria o target net10.0. A versão do pacote agora vem da tag em vez do `<Version>` fixo no csproj

## README

A seção do `Validatable` estava removida no working tree e documentava `using PMQ.Notifications.Base;` — namespace que nunca existiu. Foi reescrita com o namespace correto, a tabela de membros, o `AddFrom` e a nota de depreciação.

## Verificação

17 testes verdes em `net8.0` e `net10.0`, Release com 0 warnings.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
