### PR TITLE
📝 - Embutido o README no pacote NuGet

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,22 @@
+<Project>
+
+  <!--
+    Embute o README na raiz do .nupkg, para que a página do pacote no NuGet mostre a
+    documentação em vez de "no readme".
+
+    Fica em Directory.Build.targets, e não em Directory.Build.props, porque o caminho do
+    README precisa ser resolvido a partir da raiz do repositório e não da pasta do projeto.
+
+    Sem condição de propósito: IsPackable só recebe seu valor padrão nos targets do NuGet,
+    importados depois deste arquivo, então condicionar aqui silenciosamente não pegaria.
+    Projetos de teste não são afetados porque IsPackable=false impede o pack de rodar.
+  -->
+  <PropertyGroup>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" Visible="false" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION

O dotnet pack vinha avisando "Readme missing" e a página do pacote no NuGet ficava
sem documentação nenhuma.

Configurado em Directory.Build.targets, e não em Directory.Build.props, porque o
caminho do README precisa ser resolvido a partir da raiz do repositório.

Sem condição de IsPackable de propósito: essa propriedade só recebe o valor padrão
nos targets do NuGet, importados depois deste arquivo, então condicionar aqui não
pegaria — foi o que aconteceu na primeira tentativa, em que o README entrou no
.nupkg mas o <readme> não foi declarado no nuspec. Projetos de teste não são
afetados porque IsPackable=false impede o pack de rodar.

Verificado abrindo o .nupkg: README.md na raiz e <readme>README.md</readme> no nuspec.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)