### PR TITLE
🔖 - Bump de versão para publicar o README no pacote

### DIFF
--- a/src/PMQ.Notifications/PMQ.Notifications.csproj
+++ b/src/PMQ.Notifications/PMQ.Notifications.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>PMQ.Notifications</PackageId>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <Product>PMQ.Notifications</Product>
     <Description>
       A package for managing notifications and validations in .NET applications, making it easy to control messages, errors, and business rules in a centralized and strongly-typed way.


### PR DESCRIPTION
A correção do `PackageReadmeFile` já está no repositório, mas versão no NuGet é imutável: a página do pacote só passa a mostrar a documentação numa versão nova.

Sem mudança funcional.